### PR TITLE
moved define check if it's not in Object call.

### DIFF
--- a/src/PHPCheckstyle/PHPCheckstyle.php
+++ b/src/PHPCheckstyle/PHPCheckstyle.php
@@ -1750,10 +1750,6 @@ class PHPCheckstyle {
 	 *        	the name of the function.
 	 */
 	private function _processFunctionCall($text) {
-		if (strtolower($text) === "define") {
-			$this->_constantDef = true;
-		}
-
 		if ($this->tokenizer->checkNextValidToken(T_PARENTHESIS_OPEN)) {
 			// ASSUMPTION:that T_STRING followed by "(" is a function call
 			$this->_inFuncCall = true;
@@ -1779,6 +1775,11 @@ class PHPCheckstyle {
 
 				// Detect replaced functions
 				$this->_checkReplacements($text);
+
+				// Check if this is a constant define() function
+				if (strtolower($text) === "define") {
+					$this->_constantDef = true;
+				}
 			}
 
 			// Detect an @ before the function call


### PR DESCRIPTION
Laravel 5.6 uses $factory->define() which conflict with the define() constant defining PHP built-in function. this fix ensure this constant defining check should be called on the define() and not $object->define().